### PR TITLE
Try to fix code coverage report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     pytest-cov
     pytest-asyncio
 commands =
-    pytest tests --cov --cov-report xml
+    pytest --cov --cov-report xml
 
 [testenv:style]
 deps = pre-commit


### PR DESCRIPTION
Codecov.io was missing the source tree and only reporting stats on the test tree.
Closes #64 