### PR TITLE
make separate jobs for each python version

### DIFF
--- a/.github/workflows/py38.yml
+++ b/.github/workflows/py38.yml
@@ -1,0 +1,40 @@
+---
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: "Python ${{ matrix.python-version }}"
+    runs-on: "ubuntu-latest"
+    env:
+      USING_COVERAGE: '3.8'
+      NODE_URL: ${{ secrets.TEST_NODE_URL }} 
+      PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
+      TEST_SECRET: ${{ secrets.TEST_SECRET }}
+
+    strategy:
+      matrix:
+        python-version: ["3.8"]
+
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "${{ matrix.python-version }}"
+      - name: "Install dependencies"
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox tox-gh-actions          
+
+      - name: "Run tox targets for ${{ matrix.python-version }}"
+        run:
+          tox -e py38
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/py39.yml
+++ b/.github/workflows/py39.yml
@@ -13,14 +13,14 @@ jobs:
     name: "Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-latest"
     env:
-      USING_COVERAGE: '3.8,3.9'
+      USING_COVERAGE: '3.9'
       NODE_URL: ${{ secrets.TEST_NODE_URL }} 
       PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
       TEST_SECRET: ${{ secrets.TEST_SECRET }}
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9"]
 
     steps:
       - uses: "actions/checkout@v2"
@@ -34,14 +34,7 @@ jobs:
 
       - name: "Run tox targets for ${{ matrix.python-version }}"
         run:
-          python -c 'import os;print(os.environ)';
-          python -c 'import os;print("TEST_SECRET" in os.environ)';
-          tox -p
-        env:
-          USING_COVERAGE: '3.8,3.9'
-          NODE_URL: ${{ secrets.TEST_NODE_URL }} 
-          PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY }}
-          TEST_SECRET: ${{ secrets.TEST_SECRET }}
+          tox -e py39
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
This'll test each python version as a separate github action job.
Removes the use of `tox -p`, as the logging is quite useless in the job details (it just prints the spinning progress dots).