### PR TITLE
Add WAMPL/USD spot price pair

### DIFF
--- a/src/telliot_core/data/spot_price_pairs.json
+++ b/src/telliot_core/data/spot_price_pairs.json
@@ -1,5 +1,6 @@
 [
   "ETH/USD",
   "BTC/USD",
-  "TRB/USD"
+  "TRB/USD",
+  "WAMPL/USD"
 ]


### PR DESCRIPTION
Adds the Wrapped Ampleforth in USD spot price pair to avoid this error when using `SpotPrice` query:
```python
if (self.asset, self.currency) not in spot_price_pairs:
            raise ValueError(f"{self.asset}/{self.currency} is not a supported pair")
```