### PR TITLE
Add gas limit param to oracle writes

### DIFF
--- a/src/telliot_core/contract/contract.py
+++ b/src/telliot_core/contract/contract.py
@@ -76,7 +76,7 @@ class Contract:
         func_name: str,
         gas_price: int,
         acc_nonce: int,
-        gas_limit: int = 500000,
+        gas_limit: int,
         **kwargs: Any,
     ) -> Tuple[Optional[AttributeDict[Any, Any]], ResponseStatus]:
         """For submitting any contract transaction once without retries
@@ -149,7 +149,7 @@ class Contract:
         gas_price: int,
         extra_gas_price: int,
         retries: int,
-        gas_limit: int = 500000,
+        gas_limit: int,
         **kwargs: Any,
     ) -> Tuple[Optional[AttributeDict[Any, Any]], ResponseStatus]:
         """For submitting any contract transaction. Retries supported!

--- a/src/telliot_core/contract/contract.py
+++ b/src/telliot_core/contract/contract.py
@@ -72,7 +72,12 @@ class Contract:
             return None, ResponseStatus(ok=False, error=msg)
 
     async def write(
-        self, func_name: str, gas_price: int, acc_nonce: int, **kwargs: Any
+        self,
+        func_name: str,
+        gas_price: int,
+        acc_nonce: int,
+        gas_limit: int = 500000,
+        **kwargs: Any,
     ) -> Tuple[Optional[AttributeDict[Any, Any]], ResponseStatus]:
         """For submitting any contract transaction once without retries
 
@@ -99,8 +104,6 @@ class Contract:
             # build transaction
             contract_function = self.contract.get_function_by_name(func_name)
             transaction = contract_function(**kwargs)
-            # estimated_gas = transaction.estimateGas()
-            gas_limit = 500000  # TODO optimize for gas/profitability
             logger.info("gas limit:", gas_limit)
 
             logger.info("address: ----- ", acc.address)
@@ -146,6 +149,7 @@ class Contract:
         gas_price: int,
         extra_gas_price: int,
         retries: int,
+        gas_limit: int = 500000,
         **kwargs: Any,
     ) -> Tuple[Optional[AttributeDict[Any, Any]], ResponseStatus]:
         """For submitting any contract transaction. Retries supported!
@@ -166,6 +170,7 @@ class Contract:
                     func_name=func_name,
                     gas_price=gas_price,
                     acc_nonce=acc_nonce,
+                    gas_limit=gas_limit,
                     **kwargs,
                 )
 

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -46,6 +46,7 @@ async def test_faucet(rinkeby_cfg, master):
     # mint tokens to user
     receipt, status = await master.write_with_retry(
         func_name="setBalanceTest",
+        gas_limit=350000,
         gas_price=gas_price,
         extra_gas_price=20,
         retries=1,
@@ -82,6 +83,7 @@ async def test_trb_transfer(rinkeby_cfg, master):
         "transfer",
         _to=recipient,
         _amount=1,
+        gas_limit=350000,
         gas_price=gas_price,
         extra_gas_price=20,
         retries=2,
@@ -111,6 +113,7 @@ async def test_submit_value(rinkeby_cfg, master, oracle):
     if is_staked[0] == 0:
         _, status = await master.write_with_retry(
             func_name="depositStake",
+            gas_limit=350000,
             gas_price=gas_price_gwei,
             extra_gas_price=20,
             retries=2,
@@ -132,6 +135,7 @@ async def test_submit_value(rinkeby_cfg, master, oracle):
 
     receipt, status = await oracle.write_with_retry(
         func_name="submitValue",
+        gas_limit=350000,
         gas_price=gas_price_gwei,
         extra_gas_price=40,
         retries=5,


### PR DESCRIPTION
Removes hard-coded gas limit of 500000.