### PR TITLE
Added reporter synchronization function call

### DIFF
--- a/src/telliot_core/cli/commands/query.py
+++ b/src/telliot_core/cli/commands/query.py
@@ -3,6 +3,7 @@ import click
 from telliot_core.cli.utils import async_run
 from telliot_core.cli.utils import cli_core
 from telliot_core.data.query_catalog import query_catalog
+from telliot_core.reporters.reporter_utils import tellorx_suggested_report
 
 
 @click.group()
@@ -79,3 +80,15 @@ async def status(ctx: click.Context, query_tag: str, npoints: int) -> None:
                 f" index: {k}, timestamp: {ts}, block: {blocknum}, "
                 f"value:{value}, reporter: {reporter} "
             )
+
+
+@query.command()
+@click.pass_context
+@async_run
+async def suggest(ctx: click.Context) -> None:
+    """Get the current suggested query for reporter synchronization."""
+
+    async with cli_core(ctx) as core:
+        qtag = await tellorx_suggested_report(core.tellorx.oracle)
+        assert isinstance(qtag, str)
+        print(f"Suggested query: {qtag}")

--- a/src/telliot_core/reporters/reporter_utils.py
+++ b/src/telliot_core/reporters/reporter_utils.py
@@ -1,12 +1,11 @@
+from typing import List
 from typing import Optional
 
-from telliot_core.data.query_catalog import query_catalog
-from telliot_core.queries import OracleQuery
 from telliot_core.tellorx.oracle import TellorxOracleContract
 
 # List of currently active reporters
 
-reporter_sync_schedule = [
+reporter_sync_schedule: List[str] = [
     "eth-usd-legacy",
     "btc-usd-legacy",
     "ampl-legacy",
@@ -17,7 +16,7 @@ reporter_sync_schedule = [
 
 async def tellorx_suggested_report(
     oracle: TellorxOracleContract,
-) -> Optional[OracleQuery]:
+) -> Optional[str]:
     """Returns the currently suggested query to report against.
 
     The suggested query changes each time a block contains a query response.
@@ -29,19 +28,9 @@ async def tellorx_suggested_report(
 
     if status.ok:
         suggested_idx = timestamp.ts % len(reporter_sync_schedule)
-
-        suggested_query_tag = reporter_sync_schedule[suggested_idx]
-
-        entries = query_catalog.find(tag=suggested_query_tag)
-        if len(entries) == 0:
-            print(f"Unknown query tag: {suggested_query_tag}.")
-            return None
-        else:
-            catalog_entry = entries[0]
-            # Get the query object from the catalog entry
-            q = catalog_entry.query
-            assert isinstance(q, OracleQuery)
-            return q
+        suggested_qtag = reporter_sync_schedule[suggested_idx]
+        assert isinstance(suggested_qtag, str)
+        return suggested_qtag
 
     else:
         return None

--- a/src/telliot_core/reporters/reporter_utils.py
+++ b/src/telliot_core/reporters/reporter_utils.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+
+# List of currently active reporters
+
+from telliot_core.queries import OracleQuery
+from telliot_core.data.query_catalog import query_catalog
+from telliot_core.tellorx.oracle import TellorxOracleContract
+
+reporter_sync_schedule = [
+    'eth-usd-legacy',
+    'btc-usd-legacy',
+    'ampl-legacy',
+    'trb-usd-legacy',
+    'ohm-eth-spot'
+]
+
+
+async def tellorx_suggested_report(
+        oracle: TellorxOracleContract) -> Optional[OracleQuery]:
+    """ Returns the currently suggested query to report against.
+
+    The suggested query changes each time a block contains a query response.
+    The time of last report is used to randomly index into the
+    `report_sync_schedule` to determine the suggested query.
+
+    """
+    timestamp, status = await oracle.getTimeOfLastNewValue()
+
+    if status.ok:
+        suggested_idx = timestamp.ts % len(reporter_sync_schedule)
+
+        suggested_query_tag = reporter_sync_schedule[suggested_idx]
+
+        entries = query_catalog.find(tag=suggested_query_tag)
+        if len(entries) == 0:
+            print(f"Unknown query tag: {suggested_query_tag}.")
+            return None
+        else:
+            catalog_entry = entries[0]
+            # Get the query object from the catalog entry
+            q = catalog_entry.query
+            assert isinstance(q, OracleQuery)
+            return q
+
+    else:
+        return None

--- a/src/telliot_core/reporters/reporter_utils.py
+++ b/src/telliot_core/reporters/reporter_utils.py
@@ -1,24 +1,24 @@
 from typing import Optional
 
+from telliot_core.data.query_catalog import query_catalog
+from telliot_core.queries import OracleQuery
+from telliot_core.tellorx.oracle import TellorxOracleContract
 
 # List of currently active reporters
 
-from telliot_core.queries import OracleQuery
-from telliot_core.data.query_catalog import query_catalog
-from telliot_core.tellorx.oracle import TellorxOracleContract
-
 reporter_sync_schedule = [
-    'eth-usd-legacy',
-    'btc-usd-legacy',
-    'ampl-legacy',
-    'trb-usd-legacy',
-    'ohm-eth-spot'
+    "eth-usd-legacy",
+    "btc-usd-legacy",
+    "ampl-legacy",
+    "trb-usd-legacy",
+    "ohm-eth-spot",
 ]
 
 
 async def tellorx_suggested_report(
-        oracle: TellorxOracleContract) -> Optional[OracleQuery]:
-    """ Returns the currently suggested query to report against.
+    oracle: TellorxOracleContract,
+) -> Optional[OracleQuery]:
+    """Returns the currently suggested query to report against.
 
     The suggested query changes each time a block contains a query response.
     The time of last report is used to randomly index into the

--- a/src/telliot_core/tellorx/oracle.py
+++ b/src/telliot_core/tellorx/oracle.py
@@ -6,6 +6,7 @@ from telliot_core.contract.contract import Contract
 from telliot_core.directory.tellorx import tellor_directory
 from telliot_core.model.endpoints import RPCEndpoint
 from telliot_core.utils.response import ResponseStatus
+from telliot_core.utils.timestamp import TimeStamp
 
 ReadRespType = Tuple[Any, ResponseStatus]
 
@@ -112,7 +113,12 @@ class TellorxOracleContract(Contract):
 
         result, status = await self.read("getTimeOfLastNewValue")
 
-        return result, status
+        if status.ok:
+            t = TimeStamp(result)
+        else:
+            t = None
+
+        return t, status
 
     async def getTimestampIndexByTimestamp(
         self, queryId: str, timestamp: int

--- a/tests/test_reporter_utils.py
+++ b/tests/test_reporter_utils.py
@@ -1,11 +1,12 @@
-import asyncio
-from telliot_core.apps.core import TelliotCore
-from telliot_core.reporters.reporter_utils import tellorx_suggested_report
 import pytest
+
+from telliot_core.apps.core import TelliotCore
+from telliot_core.queries import OracleQuery
+from telliot_core.reporters.reporter_utils import tellorx_suggested_report
 
 
 @pytest.mark.asyncio
 async def test_suggested_report(rinkeby_cfg):
     async with TelliotCore(config=rinkeby_cfg) as core:
         q = await tellorx_suggested_report(core.tellorx.oracle)
-        print(q)
+        assert isinstance(q, OracleQuery)

--- a/tests/test_reporter_utils.py
+++ b/tests/test_reporter_utils.py
@@ -1,0 +1,11 @@
+import asyncio
+from telliot_core.apps.core import TelliotCore
+from telliot_core.reporters.reporter_utils import tellorx_suggested_report
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_suggested_report(rinkeby_cfg):
+    async with TelliotCore(config=rinkeby_cfg) as core:
+        q = await tellorx_suggested_report(core.tellorx.oracle)
+        print(q)

--- a/tests/test_reporter_utils.py
+++ b/tests/test_reporter_utils.py
@@ -1,6 +1,9 @@
 import pytest
+from click.testing import CliRunner
 
+import telliot_core.cli.main
 from telliot_core.apps.core import TelliotCore
+from telliot_core.data.query_catalog import query_catalog
 from telliot_core.queries import OracleQuery
 from telliot_core.reporters.reporter_utils import tellorx_suggested_report
 
@@ -8,5 +11,19 @@ from telliot_core.reporters.reporter_utils import tellorx_suggested_report
 @pytest.mark.asyncio
 async def test_suggested_report(rinkeby_cfg):
     async with TelliotCore(config=rinkeby_cfg) as core:
-        q = await tellorx_suggested_report(core.tellorx.oracle)
+        qtag = await tellorx_suggested_report(core.tellorx.oracle)
+        assert isinstance(qtag, str)
+        entries = query_catalog.find(tag=qtag)
+        assert len(entries) == 1
+        catalog_entry = entries[0]
+        q = catalog_entry.query
         assert isinstance(q, OracleQuery)
+
+
+def test_suggested_report_cli():
+    """Test suggested report CLI"""
+    runner = CliRunner()
+    result = runner.invoke(
+        telliot_core.cli.main.main, ["--test_config", "query", "suggest"]
+    )
+    assert "Suggested query" in result.output


### PR DESCRIPTION
Closes #173 

Reporters can now stay in sync with other reporters.  
The `tellorx_suggested_report` function will return the currently suggested `OracleQuery` to respond to.  The response will change each block that contains a new oracle query response.

```
async def test_suggested_report(rinkeby_cfg):
    async with TelliotCore(config=rinkeby_cfg) as core:
        q = await tellorx_suggested_report(core.tellorx.oracle)
        print(q)
```

## Design 

- We want a function that returns the same suggested query for all reporters at any given time.  
- Ideally, it should change each time a query response is submitted to the block chain.
- `telliot-core` will maintain a list of "active" queries, from which to pick the suggestion.
- The oracle `getTimeOfLastNewValue` will be used to get the integer timestamp of the most recent oracle submission
- This timestamp will be used to randomly index the active query table (using a simple modulo function) to choose the current query
- This design will give all queries in the table the same chance of getting a report, though the ordering will be random.

