### PR TITLE
Move write_with_retries to standalone function

### DIFF
--- a/src/telliot_core/contract/contract.py
+++ b/src/telliot_core/contract/contract.py
@@ -75,11 +75,11 @@ class Contract:
     async def write(
         self,
         func_name: str,
-        acc_nonce: int,
         gas_limit: int,
         legacy_gas_price: Optional[int] = None,
         max_priority_fee_per_gas: Optional[int] = None,
         max_fee_per_gas: Optional[int] = None,
+        acc_nonce: Optional[int] = None,
         **kwargs: Any,
     ) -> Tuple[Optional[AttributeDict[Any, Any]], ResponseStatus]:
         """For submitting any contract transaction once without retries
@@ -88,7 +88,27 @@ class Contract:
 
         """
 
+        # Validate inputs
+        if (legacy_gas_price is not None) and (
+            (max_fee_per_gas is not None) or (max_priority_fee_per_gas is not None)
+        ):
+            raise ValueError(
+                """invalid combination of legacy gas arguments
+                 and EIP-1559 gas arguments"""
+            )
+
+        if (
+            (legacy_gas_price is None)
+            and (max_fee_per_gas is None)
+            and (max_priority_fee_per_gas is None)
+        ):
+            raise ValueError("no gas strategy selected!")
+
         status = ResponseStatus()
+
+        if not acc_nonce:
+            acc = self.node.web3.eth.account.from_key(self.private_key)
+            acc_nonce = self.node.web3.eth.get_transaction_count(acc.address)
 
         if not self.contract:
             msg = f"Contract.write({func_name}) error: Unable to connect to contract"
@@ -201,166 +221,6 @@ class Contract:
         except Exception as e:
             note = "Failed to confirm transaction"
             return None, error_status(note, log=logger.error, e=e)
-
-    async def write_with_retry(
-        self,
-        func_name: str,
-        extra_gas_price: int,
-        retries: int,
-        gas_limit: int,
-        legacy_gas_price: Optional[int] = None,
-        max_priority_fee_per_gas: Optional[int] = None,
-        max_fee_per_gas: Optional[int] = None,
-        **kwargs: Any,
-    ) -> Tuple[Optional[AttributeDict[Any, Any]], ResponseStatus]:
-        """For submitting any contract transaction.
-        Will attempt to retry (resubmit) the transaction a set number of times
-        if it fails to be picked up by the chain.
-        Can submit a tx with either legacy gas strategy
-        or the London fork EIP-1559 strategy
-
-        Quick explainer...
-        Legacy: gas cost = gasLimit*gasPrice where...
-         - you set the gas price (simple as that!)
-        EIP-1559: gas cost = gasLimit*(baseFee+priorityFee) where...
-         - you can set the highest priorityFee you would pay (max_priority_fee_per_gas)
-         OR
-         - you can set the highest maxFee (i.e. baseFee+priorityFee)
-           you are willing to pay (ths is the max_fee_per_gas)
-        also...
-         - baseFee is set by the block
-
-        Args:
-            func_name (str): name of contract function
-            extra_gas_price (int): the amount of gas the tx resends
-                with if it fails due to gas strategy
-                (adds to legacy_gas_price or max_priority_fee_per_gas
-                depending on tx gas strategy)
-            retries (int): number of times to attempt tx resubmission
-            gas_limit (int): the maximum amount of gas units (not gas price!)
-                to assign to the tx
-            legacy_gas_price (int): the legacy gas price for a legacy tx
-            max_priority_fee_per_gas (int): the highest priorityFee in gwei
-                you would pay (see guide above)
-            max_fee_per_gas (int): the highest maxFee in gwei
-                (baseFee+priorityFee) you would pay (see guide above)
-
-        Returns:
-            transaction receipt (if transaction is picked up by chain)
-            ResponseStatus (status of tx success)
-
-
-        """
-        if (legacy_gas_price is not None) and (
-            (max_fee_per_gas is not None) or (max_priority_fee_per_gas is not None)
-        ):
-            raise ValueError(
-                """invalid combination of legacy gas arguments
-                 and EIP-1559 modern gas arguments"""
-            )
-
-        if (
-            (legacy_gas_price is None)
-            and (max_fee_per_gas is None)
-            and (max_priority_fee_per_gas is None)
-        ):
-            raise ValueError("no gas strategy selected!")
-
-        try:
-            status = ResponseStatus()
-            acc = self.node.web3.eth.account.from_key(self.private_key)
-            acc_nonce = self.node.web3.eth.get_transaction_count(acc.address)
-
-            # Iterate through retry attempts
-            for k in range(retries + 1):
-
-                attempt = k + 1
-
-                if k >= 1:
-                    logger.info(f"Retrying {func_name} (attempt #{attempt})")
-
-                # Attempt write
-                tx_receipt, status = await self.write(
-                    func_name=func_name,
-                    legacy_gas_price=legacy_gas_price,
-                    max_priority_fee_per_gas=max_priority_fee_per_gas,
-                    max_fee_per_gas=max_fee_per_gas,
-                    acc_nonce=acc_nonce,
-                    gas_limit=gas_limit,
-                    **kwargs,
-                )
-
-                logger.debug(f"Attempt {attempt} status: ", status)
-
-                # Exit loop if transaction successful
-                if (
-                    status.ok
-                    and (tx_receipt is not None)
-                    and (tx_receipt["status"] == 1)
-                ):
-                    return tx_receipt, status
-
-                else:
-                    logger.info(f"Write attempt {attempt} failed:")
-                    msg = str(status.error)
-                    _ = error_status(msg, log=logger.info)
-
-                    if tx_receipt is not None:
-                        tx_url = f"{self.node.explorer}/tx/{tx_receipt['transactionHash'].hex()}"  # noqa: E501
-
-                        if tx_receipt["status"] == 0:
-                            msg = f"Write attempt {attempt} failed, tx reverted ({tx_url}):"  # noqa: E501
-                            return tx_receipt, error_status(msg, log=logger.info)
-
-                        else:
-                            msg = f"Write attempt {attempt}: Invalid TX Receipt status: {tx_receipt['status']}"  # noqa: E501
-                            return tx_receipt, error_status(msg, log=logger.info)
-
-                    if status.error:
-                        if "replacement transaction underpriced" in status.error:
-                            if legacy_gas_price is not None:
-                                legacy_gas_price += extra_gas_price
-                                logger.info(f"Next gas price: {legacy_gas_price}")
-                            elif max_fee_per_gas is not None:
-                                max_fee_per_gas += extra_gas_price
-                                logger.info(f"Next max fee: {max_fee_per_gas}")
-                            elif max_priority_fee_per_gas is not None:
-                                max_priority_fee_per_gas += extra_gas_price
-                                logger.info(
-                                    f"Next priority fee: {max_priority_fee_per_gas}"
-                                )
-                        elif "already known" in status.error:
-                            acc_nonce += 1
-                            logger.info(f"Incrementing nonce: {acc_nonce}")
-                        elif "nonce too low" in status.error:
-                            acc_nonce += 1
-                            logger.info(f"Incrementing nonce: {acc_nonce}")
-                        # a different rpc error
-                        elif "nonce is too low" in status.error:
-                            acc_nonce += 1
-                            logger.info(f"Incrementing nonce: {acc_nonce}")
-                        elif "not in the chain" in status.error:
-                            if legacy_gas_price is not None:
-                                legacy_gas_price += extra_gas_price
-                                logger.info(f"Next gas price: {legacy_gas_price}")
-                            elif max_fee_per_gas is not None:
-                                max_fee_per_gas += extra_gas_price
-                                logger.info(f"Next max fee: {max_fee_per_gas}")
-                            elif max_priority_fee_per_gas is not None:
-                                max_priority_fee_per_gas += extra_gas_price
-                                logger.info(
-                                    f"Next priority fee: {max_priority_fee_per_gas}"
-                                )
-                        else:
-                            extra_gas_price = 0
-
-            status.ok = False
-            status.error = "ran out of retries, tx unsuccessful"
-
-            return tx_receipt, status
-
-        except Exception as e:
-            return None, error_status("Other error", log=logger.error, e=e)
 
     def listen(self) -> None:
         """Wrapper for listening for contract events"""

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -33,19 +33,18 @@ async def test_call_read_function(rinkeby_cfg):
 
 @pytest.mark.asyncio
 async def test_mixed_gas_inputs(rinkeby_cfg):
-    """Contract.write_with_retry() should refuse a combination of
+    """Contract.write() should refuse a combination of
     legacy gas args and EIP-1559 gas args"""
 
     with pytest.raises(ValueError):
 
         async with TelliotCore(config=rinkeby_cfg) as core:
 
-            tx_receipt, status = await core.tellorx.oracle.write_with_retry(
+            tx_receipt, status = await core.tellorx.oracle.write(
                 func_name="transfer",
                 _to="0xF90cd1D6C1da49CE2cF5C39f82999D7145aa66aD",
                 _amount=1,
                 extra_gas_price=0,
-                retries=0,
                 gas_limit=350000,
                 legacy_gas_price=1,
                 max_fee_per_gas=2,


### PR DESCRIPTION
Moving `write_with_retry` to contract utilities in feed-examples, since it's more of a custom user implementation.