### PR TITLE
Add polygon testnet endpoint to defaults

### DIFF
--- a/src/telliot_core/model/endpoints.py
+++ b/src/telliot_core/model/endpoints.py
@@ -107,7 +107,7 @@ default_endpoint_list = [
         chain_id=80001,
         provider="Matic",
         network="mumbai",
-        url="",
+        url="https://polygon-mumbai.infura.io/v3/{INFURA_API_KEY}",
         explorer="https://mumbai.polygonscan.com/",
     ),
 ]

--- a/src/telliot_core/model/endpoints.py
+++ b/src/telliot_core/model/endpoints.py
@@ -103,6 +103,13 @@ default_endpoint_list = [
         url="https://rpc-mainnet.matic.network",
         explorer="https://matic.network",
     ),
+    RPCEndpoint(
+        chain_id=80001,
+        provider="Matic",
+        network="mumbai",
+        url="",
+        explorer="https://mumbai.polygonscan.com/",
+    ),
 ]
 
 


### PR DESCRIPTION
Adds Polygon Mumbai endpoint info to default yaml file.
```yaml
type: EndpointList
endpoints:
- type: RPCEndpoint
  chain_id: 80001
  network: mumbai
  provider: Matic
  url: https://polygon-mumbai.infura.io/v3/{INFURA_API_KEY}
  explorer: https://mumbai.polygonscan.com/
```