### PR TITLE
Require web3 >= 5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     click
     PyYAML
     requests
-    web3
+    web3>=5.26.0
     clamfig
     chained-accounts
     boto3


### PR DESCRIPTION
Closes #215 , since the deprecation error from eth_utils occurs when `web3` < 5.0.0 is used