### PR TITLE
Add support for Ropsten testnet playground

### DIFF
--- a/.github/workflows/py39.yml
+++ b/.github/workflows/py39.yml
@@ -19,6 +19,7 @@ jobs:
       TEST_SECRET: ${{ secrets.TEST_SECRET }}
       RAPID_KEY: ${{ secrets.TEST_RAPID_KEY }}
       ANYBLOCK_KEY: ${{ secrets.TEST_ANYBLOCK_KEY }}
+      INFURA_API_KEY: ${{ secrets.INFURA_API_KEY }}
 
     strategy:
       matrix:

--- a/src/telliot_core/apps/core.py
+++ b/src/telliot_core/apps/core.py
@@ -24,14 +24,15 @@ from telliot_core.tellor.tellorx.oracle import TellorxOracleContract
 from telliot_core.utils.home import telliot_homedir
 from telliot_core.utils.versions import show_telliot_versions
 
-networks = {
+NETWORKS = {
     1: "eth-mainnet",
+    3: "eth-ropsten",
     4: "eth-rinkeby",
     137: "polygon-mainnet",
     80001: "polygon-mumbai",
 }
 
-loglevel_map = {
+LOGLEVEL_MAP = {
     "CRITICAL": logging.CRITICAL,
     "ERROR": logging.ERROR,
     "WARNING": logging.WARNING,
@@ -166,7 +167,7 @@ class TelliotCore:
         self._tellorx = None
         self._tellorflex = None
 
-        loglevel = loglevel_map[self._config.main.loglevel]
+        loglevel = LOGLEVEL_MAP[self._config.main.loglevel]
         self._log = init_logging(loglevel)
 
         if chain_id is not None:
@@ -196,7 +197,7 @@ class TelliotCore:
 
         await self._session_manager.open()
 
-        msg = f"Connected to {networks[chain_id]} [default account: {account.name}], time: {datetime.now()}"
+        msg = f"Connected to {NETWORKS[chain_id]} [default account: {account.name}], time: {datetime.now()}"
         self.log.info(msg)
 
     def get_endpoint(

--- a/src/telliot_core/data/contract_directory.json
+++ b/src/telliot_core/data/contract_directory.json
@@ -55,7 +55,8 @@
     "org": "tellor",
     "address": {
       "137": "0xFd45Ae72E81Adaaf01cC61c8bCe016b7060DD537",
-      "80001": "0x41b66dd93b03e89D29114a7613A6f9f0d4F40178"
+      "80001": "0x41b66dd93b03e89D29114a7613A6f9f0d4F40178",
+      "3": "0xF281e2De3bB71dE348040b10B420615104359c10"
     },
     "abi_file": "tellorflex-oracle-abi.json"
   },
@@ -65,7 +66,8 @@
     "org": "tellor",
     "address": {
       "137": "0xE3322702BEdaaEd36CdDAb233360B939775ae5f1",
-      "80001": "0x45cAF1aae42BA5565EC92362896cc8e0d55a2126"
+      "80001": "0x45cAF1aae42BA5565EC92362896cc8e0d55a2126",
+      "3": "0xF281e2De3bB71dE348040b10B420615104359c10"
     },
     "abi_file": "polygon-token-abi.json"
   },
@@ -93,7 +95,8 @@
     "org": "tellor",
     "address": {
       "4": "0xF281e2De3bB71dE348040b10B420615104359c10",
-      "42": "0x320f09D9f92Cfa0e9C272b179e530634D873aeFa"
+      "42": "0x320f09D9f92Cfa0e9C272b179e530634D873aeFa",
+      "3": "0xF281e2De3bB71dE348040b10B420615104359c10"
     }
   },
   {

--- a/src/telliot_core/model/endpoints.py
+++ b/src/telliot_core/model/endpoints.py
@@ -88,6 +88,13 @@ default_endpoint_list = [
         explorer="https://etherscan.io",
     ),
     RPCEndpoint(
+        chain_id=3,
+        provider="Infura",
+        network="ropsten",
+        url="wss://ropsten.infura.io/ws/v3{INFURA_API_KEY}",
+        explorer="https://ropsten.etherscan.io",
+    ),
+    RPCEndpoint(
         chain_id=4,
         provider="Infura",
         network="rinkeby",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def rinkeby_cfg():
         if key:
             ChainedAccount.add("git-rinkeby-key", chains=4, key=os.environ["PRIVATE_KEY"], password="")
         else:
-            raise Exception("Need a mumbai account")
+            raise Exception("Need a rinkeby account")
 
     return cfg
 
@@ -45,7 +45,7 @@ def mumbai_cfg():
     """
     cfg = TelliotConfig()
 
-    # Override configuration for rinkeby testnet
+    # Override configuration for mumbai testnet
     cfg.main.chain_id = 80001
 
     mumbai_accounts = find_accounts(chain_id=80001)
@@ -54,6 +54,29 @@ def mumbai_cfg():
         key = os.getenv("PRIVATE_KEY", None)
         if key:
             ChainedAccount.add("git-mumbai-key", chains=80001, key=os.environ["PRIVATE_KEY"], password="")
+        else:
+            raise Exception("Need a mumbai account")
+
+    return cfg
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ropsten_cfg():
+    """Return a test telliot configuration for use on polygon-mumbai
+
+    If environment variables are defined, they will override the values in config files
+    """
+    cfg = TelliotConfig()
+
+    # Override configuration for ropsten testnet
+    cfg.main.chain_id = 3
+
+    mumbai_accounts = find_accounts(chain_id=3)
+    if not mumbai_accounts:
+        # Create a test account using PRIVATE_KEY defined on github.
+        key = os.getenv("PRIVATE_KEY", None)
+        if key:
+            ChainedAccount.add("git-ropsten-key", chains=3, key=os.environ["PRIVATE_KEY"], password="")
         else:
             raise Exception("Need a mumbai account")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,8 +71,12 @@ def ropsten_cfg():
     # Override configuration for ropsten testnet
     cfg.main.chain_id = 3
 
-    mumbai_accounts = find_accounts(chain_id=3)
-    if not mumbai_accounts:
+    endpt = cfg.get_endpoint()
+    if "INFURA_API_KEY" in endpt.url:
+        endpt.url = f'wss://ropsten.infura.io/ws/v3/{os.environ["INFURA_API_KEY"]}'
+
+    accounts = find_accounts(chain_id=3)
+    if not accounts:
         # Create a test account using PRIVATE_KEY defined on github.
         key = os.getenv("PRIVATE_KEY", None)
         if key:

--- a/tests/test_rpc_endpoint.py
+++ b/tests/test_rpc_endpoint.py
@@ -43,3 +43,6 @@ def test_endpoint_list():
     # print(json.dumps(sl.get_state(), indent=2))
     ep4 = sl.find(chain_id=4)[0]
     assert ep4.network == "rinkeby"
+
+    ep3 = sl.find(chain_id=3)[0]
+    assert ep3.network == "ropsten"

--- a/tests/test_tellorplayground_ropsten.py
+++ b/tests/test_tellorplayground_ropsten.py
@@ -1,0 +1,51 @@
+import pytest
+
+from telliot_core.apps.core import TelliotCore
+from telliot_core.queries.price.spot_price import SpotPrice
+from telliot_core.utils.response import ResponseStatus
+from telliot_core.utils.timestamp import TimeStamp
+
+
+@pytest.mark.asyncio
+async def test_main(ropsten_cfg):
+    async with TelliotCore(config=ropsten_cfg) as core:
+
+        chain_id = core.config.main.chain_id
+
+        # Playground contract address used for all tellorflex contract addresses
+        # since it contains all functions needed.
+        flex = core.get_tellorflex_contracts()
+
+        assert flex.oracle.address == "0xF281e2De3bB71dE348040b10B420615104359c10"
+        assert flex.token.address == "0xF281e2De3bB71dE348040b10B420615104359c10"
+
+        tlnv, status = await flex.oracle.get_time_of_last_new_value()
+        assert isinstance(status, ResponseStatus)
+        if status.ok:
+            assert isinstance(tlnv, TimeStamp)
+        else:
+            assert tlnv is None
+        print(tlnv)
+
+        lock = await flex.oracle.get_reporting_lock()
+        print(lock)
+
+        total_stake = await flex.oracle.get_total_stake_amount()
+        print(f"Total Stake: {total_stake}")
+
+        staker_info, status = await flex.oracle.get_staker_info(core.get_account().address)
+        assert isinstance(status, ResponseStatus)
+        if status.ok:
+            for info in staker_info:
+                assert isinstance(info, int)
+        else:
+            assert staker_info is None
+
+        q = SpotPrice(asset="btc", currency="USD")
+        count, status = await flex.oracle.get_new_value_count_by_qeury_id(q.query_id)
+
+        assert isinstance(status, ResponseStatus)
+        if status.ok:
+            assert isinstance(count, int)
+        else:
+            assert count is None

--- a/tests/test_tellorplayground_ropsten.py
+++ b/tests/test_tellorplayground_ropsten.py
@@ -10,8 +10,6 @@ from telliot_core.utils.timestamp import TimeStamp
 async def test_main(ropsten_cfg):
     async with TelliotCore(config=ropsten_cfg) as core:
 
-        chain_id = core.config.main.chain_id
-
         # Playground contract address used for all tellorflex contract addresses
         # since it contains all functions needed.
         flex = core.get_tellorflex_contracts()


### PR DESCRIPTION
Closes #218 

Overrides flex address and token address in contract directory in /data. Eventually, should create a separate playground contract, rather than hacking the polygon one