### PR TITLE
Update Diva query parameter name

### DIFF
--- a/src/telliot_core/queries/diva_protocol.py
+++ b/src/telliot_core/queries/diva_protocol.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 # TODO
 # This is a very minimal implementation of what is needed for Diva.
-# Eventually, it'll need to fetch a viable optionID automatically and
+# Eventually, it'll need to fetch a viable poolId automatically and
 # it's associated response type from the DIVA contract
 @dataclass
 class divaProtocolPolygon(AbiQuery):
@@ -18,7 +18,7 @@ class divaProtocolPolygon(AbiQuery):
     Diva Protocol on Polygon.
 
     Attributes:
-        option_id:
+        poolId:
             Specifies the requested data a of a valid prediction market that's ready to
             be settled on the Diva Protocol, on the Polygon network.
 
@@ -29,10 +29,10 @@ class divaProtocolPolygon(AbiQuery):
             https://divaprotocol.io
     """
 
-    optionID: int
+    poolId: int
 
     #: ABI used for encoding/decoding parameters
-    abi = [{"name": "optionID", "type": "uint256"}]
+    abi = [{"name": "poolId", "type": "uint256"}]
 
     @property
     def value_type(self) -> ValueType:

--- a/tests/test_query_diva_protocol_polygon.py
+++ b/tests/test_query_diva_protocol_polygon.py
@@ -10,7 +10,7 @@ from telliot_core.queries.diva_protocol import divaProtocolPolygon
 
 def test_constructor():
     """Validate spot price query."""
-    q = divaProtocolPolygon(optionID=156)
+    q = divaProtocolPolygon(poolId=156)
 
     # print(q.query_id.hex())
     # print(q.query_data)
@@ -22,8 +22,8 @@ def test_constructor():
     query_type, encoded_param_vals = decode_abi(["string", "bytes"], q.query_data)
     assert query_type == "divaProtocolPolygon"
 
-    option_id = decode_abi([q.abi[0]["type"]], encoded_param_vals)[0]
-    assert option_id == 156
+    pool_id = decode_abi([q.abi[0]["type"]], encoded_param_vals)[0]
+    assert pool_id == 156
 
     exp = "96ed1e09bc6d42fa15911c36b46dd451f93ce45ecdb19fd46ecf784656a53d84"
     assert q.query_id.hex() == exp


### PR DESCRIPTION
Closes #220 so it's now poolId, corresponding w/ [diva data spec](https://github.com/tellor-io/dataSpecs/blob/main/types/DivaProtocolPolygon.md) and diva contracts