### PR TITLE
Add default API key list

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,14 +97,14 @@ type: ApiKeyList
 api_keys:
 - type: ApiKey
   name: anyblock
-  key: '{YOUR API KEY GOES HERE}'
+  key: 'YOUR API KEY GOES HERE'
   url: https://api.anyblock.tools/
 - type: ApiKey
   name: bravenewcoin
-  key: '{YOUR API KEY GOES HERE}'
+  key: 'YOUR API KEY GOES HERE'
   url: https://bravenewcoin.p.rapidapi.com/
 - type: ApiKey
   name: nomics
-  key: '{YOUR API KEY GOES HERE}'
+  key: 'YOUR API KEY GOES HERE'
   url: https://api.nomics.com/
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,11 +10,7 @@ First, create the default configuration files:
 
     telliot config init
 
-The default configuration files are created in a folder called `telliot` in the user home folder:
-
-    Saved config 'main' to ~/telliot/main.yaml
-    Saved config 'endpoints' to ~/telliot/endpoints.yaml
-    Saved config 'chains' to ~/telliot/chains.json
+The default configuration files are created in a folder called `telliot` in the user home folder.
 
 To show the current configuration:
 
@@ -91,3 +87,24 @@ endpoints:
 
 ```
 
+### Add API Keys
+
+Some data sources used for reporting require you to set up an account and use an API key for authenticating requests. Edit `~/telliot/api_keys.yaml` to add any API keys needed for reporting data like AMPL/USD/VWAP and BCT/USD.
+
+*Example `api_keys.yaml` file:*
+```yaml
+type: ApiKeyList
+api_keys:
+- type: ApiKey
+  name: anyblock
+  key: '{YOUR API KEY GOES HERE}'
+  url: https://api.anyblock.tools/
+- type: ApiKey
+  name: bravenewcoin
+  key: '{YOUR API KEY GOES HERE}'
+  url: https://bravenewcoin.p.rapidapi.com/
+- type: ApiKey
+  name: nomics
+  key: '{YOUR API KEY GOES HERE}'
+  url: https://api.nomics.com/
+```

--- a/src/telliot_core/apps/telliot_config.py
+++ b/src/telliot_core/apps/telliot_config.py
@@ -11,6 +11,7 @@ from chained_accounts import find_accounts
 
 from telliot_core.apps.config import ConfigFile
 from telliot_core.apps.config import ConfigOptions
+from telliot_core.model.api_keys import ApiKeyList
 from telliot_core.model.base import Base
 from telliot_core.model.chain import ChainList
 from telliot_core.model.endpoints import EndpointList
@@ -42,11 +43,14 @@ class TelliotConfig(Base):
 
     endpoints: EndpointList = field(default_factory=EndpointList)
 
+    api_keys: ApiKeyList = field(default_factory=ApiKeyList)
+
     chains: ChainList = field(default_factory=ChainList)
 
     # Private storage for config files
     _main_config_file: Optional[ConfigFile] = None
     _ep_config_file: Optional[ConfigFile] = None
+    _api_keys_config_file: Optional[ConfigFile] = None
     _chain_config_file: Optional[ConfigFile] = None
 
     def __post_init__(self) -> None:
@@ -62,6 +66,12 @@ class TelliotConfig(Base):
             config_format="yaml",
             config_dir=self.config_dir,
         )
+        self._api_keys_config_file = ConfigFile(
+            name="api_keys",
+            config_type=ApiKeyList,
+            config_format="yaml",
+            config_dir=self.config_dir,
+        )
         self._chain_config_file = ConfigFile(
             name="chains",
             config_type=ChainList,
@@ -71,6 +81,7 @@ class TelliotConfig(Base):
 
         self.main = self._main_config_file.get_config()
         self.endpoints = self._ep_config_file.get_config()
+        self.api_keys = self._api_keys_config_file.get_config()
         self.chains = self._chain_config_file.get_config()
 
     def get_endpoint(self) -> RPCEndpoint:

--- a/src/telliot_core/model/api_keys.py
+++ b/src/telliot_core/model/api_keys.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass
 from dataclasses import field
 from typing import List
+from typing import Optional
 
 from telliot_core.apps.config import ConfigFile
 from telliot_core.apps.config import ConfigOptions
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ApiKey(Base):
-    """JSON RPC Endpoint for EVM compatible network"""
+    """API Key used for a data source."""
 
     #: API key name
     name: str = ""
@@ -23,30 +24,49 @@ class ApiKey(Base):
     #: API key (secret)
     key: str = ""
 
+    #: Associated URL
+    url: str = ""
+
 
 default_api_keys = [
-    ApiKey(
-        name="anyblock",
-        key="",
-    ),
+    ApiKey(name="anyblock", key="", url="https://api.anyblock.tools/"),
     ApiKey(
         name="bravenewcoin",
         key="",
+        url="https://bravenewcoin.p.rapidapi.com/",
     ),
     ApiKey(
         name="nomics",
         key="",
-    )
+        url="https://api.nomics.com/",
+    ),
 ]
 
 
 @dataclass
 class ApiKeyList(ConfigOptions):
-    endpoints: List[ApiKey] = field(default_factory=lambda: default_api_keys)
+    api_keys: List[ApiKey] = field(default_factory=lambda: default_api_keys)
 
-    def find() -> None:
-        # TODO
-        pass
+    def find(
+        self,
+        *,
+        name: Optional[str] = None,
+        url: Optional[str] = None,
+    ) -> list[ApiKey]:
+
+        result = []
+        for api_key in self.api_keys:
+
+            if name is not None:
+                if name != api_key.name:
+                    continue
+            if url is not None:
+                if url != api_key.url:
+                    continue
+
+            result.append(api_key)
+
+        return result
 
 
 if __name__ == "__main__":

--- a/src/telliot_core/model/api_keys.py
+++ b/src/telliot_core/model/api_keys.py
@@ -1,0 +1,57 @@
+"""
+Config file for user API keys for data sources.
+"""
+import logging
+from dataclasses import dataclass
+from dataclasses import field
+from typing import List
+
+from telliot_core.apps.config import ConfigFile
+from telliot_core.apps.config import ConfigOptions
+from telliot_core.model.base import Base
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ApiKey(Base):
+    """JSON RPC Endpoint for EVM compatible network"""
+
+    #: API key name
+    name: str = ""
+
+    #: API key (secret)
+    key: str = ""
+
+
+default_api_keys = [
+    ApiKey(
+        name="anyblock",
+        key="",
+    ),
+    ApiKey(
+        name="bravenewcoin",
+        key="",
+    ),
+    ApiKey(
+        name="nomics",
+        key="",
+    )
+]
+
+
+@dataclass
+class ApiKeyList(ConfigOptions):
+    endpoints: List[ApiKey] = field(default_factory=lambda: default_api_keys)
+
+    def find() -> None:
+        # TODO
+        pass
+
+
+if __name__ == "__main__":
+    cf = ConfigFile(name="api_keys", config_type=ApiKeyList, config_format="yaml")
+
+    config_endpoints = cf.get_config()
+
+    print(config_endpoints)

--- a/src/telliot_core/model/api_keys.py
+++ b/src/telliot_core/model/api_keys.py
@@ -35,11 +35,7 @@ default_api_keys = [
         key="",
         url="https://bravenewcoin.p.rapidapi.com/",
     ),
-    ApiKey(
-        name="nomics",
-        key="",
-        url="https://api.nomics.com/",
-    ),
+    ApiKey(name="nomics", key="", url="https://api.nomics.com/"),
 ]
 
 
@@ -49,7 +45,6 @@ class ApiKeyList(ConfigOptions):
 
     def find(
         self,
-        *,
         name: Optional[str] = None,
         url: Optional[str] = None,
     ) -> list[ApiKey]:

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,14 @@
+"""
+Tests covering Pytelliot data source API key utils.
+"""
+from telliot_core.model.api_keys import ApiKeyList
+
+
+def test_api_key_list():
+    lis = ApiKeyList()
+    # print(json.dumps(sl.get_state(), indent=2))
+    res = lis.find(name="bravenewcoin")[0]
+    assert res.url == "https://bravenewcoin.p.rapidapi.com/"
+
+    res = lis.find(url="https://api.nomics.com/")[0]
+    assert res.name == "nomics"

--- a/tests/test_telliot_config.py
+++ b/tests/test_telliot_config.py
@@ -12,6 +12,7 @@ def prep_dir(clean=False):
 
     main_file = tmpdir / "main.yaml"
     ep_file = tmpdir / "endpoints.yaml"
+    api_keys_file = tmpdir / "api_keys.yaml"
     chain_file = tmpdir / "chains.json"
     directory_file = tmpdir / "directory.json"
 
@@ -20,6 +21,8 @@ def prep_dir(clean=False):
             os.remove(main_file)
         if ep_file.exists():
             os.remove(ep_file)
+        if api_keys_file.exists():
+            os.remove(api_keys_file)
         if chain_file.exists():
             os.remove(chain_file)
         if directory_file.exists():
@@ -36,5 +39,8 @@ def test_telliot_config():
 
     ep = cfg.get_endpoint()
     assert isinstance(ep, RPCEndpoint)
+
+    api_key = cfg.api_keys.find("anyblock")[0]
+    assert api_key.url == "https://api.anyblock.tools/"
 
     tmpdir = prep_dir(clean=True)


### PR DESCRIPTION
Demo:
```python
cfg = TelliotConfig()
print(cfg.api_keys.find(name="nomics")
```

Closes #234 