### PR TITLE
Fix default endpoints

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,7 +82,7 @@ endpoints:
   chain_id: 4
   network: rinkeby
   provider: Infura
-  url: wss://rinkeby.infura.io/ws/v3{INFURA_API_KEY}
+  url: wss://rinkeby.infura.io/ws/v3/{INFURA_API_KEY}
   explorer: https://rinkeby.etherscan.io
 
 ```

--- a/src/telliot_core/model/endpoints.py
+++ b/src/telliot_core/model/endpoints.py
@@ -91,14 +91,14 @@ default_endpoint_list = [
         chain_id=3,
         provider="Infura",
         network="ropsten",
-        url="wss://ropsten.infura.io/ws/v3{INFURA_API_KEY}",
+        url="wss://ropsten.infura.io/ws/v3/{INFURA_API_KEY}",
         explorer="https://ropsten.etherscan.io",
     ),
     RPCEndpoint(
         chain_id=4,
         provider="Infura",
         network="rinkeby",
-        url="wss://rinkeby.infura.io/ws/v3{INFURA_API_KEY}",
+        url="wss://rinkeby.infura.io/ws/v3/{INFURA_API_KEY}",
         explorer="https://rinkeby.etherscan.io",
     ),
     RPCEndpoint(


### PR DESCRIPTION
Default endpoints were missing a "/" before where api key goes.