### PR TITLE
Fix reporter sync schedule bug

### DIFF
--- a/src/telliot_core/reporters/reporter_utils.py
+++ b/src/telliot_core/reporters/reporter_utils.py
@@ -8,6 +8,8 @@ from telliot_core.tellor.tellorx.oracle import TellorxOracleContract
 
 # List of currently active reporters
 reporter_sync_schedule: List[str] = list(query_catalog._entries.keys())
+reporter_sync_schedule.remove("uspce-legacy")
+reporter_sync_schedule.remove("morphware-v1")
 print(reporter_sync_schedule)
 
 

--- a/src/telliot_core/reporters/reporter_utils.py
+++ b/src/telliot_core/reporters/reporter_utils.py
@@ -7,9 +7,9 @@ from telliot_core.tellor.tellorflex.oracle import TellorFlexOracleContract
 from telliot_core.tellor.tellorx.oracle import TellorxOracleContract
 
 # List of currently active reporters
-reporter_sync_schedule: List[str] = list(query_catalog._entries.keys())
+reporter_sync_schedule: List[str] = [qt for qt in query_catalog._entries.keys() if "legacy" in qt or "spot" in qt]
 reporter_sync_schedule.remove("uspce-legacy")
-reporter_sync_schedule.remove("morphware-v1")
+reporter_sync_schedule.remove("ampl-legacy")
 print(reporter_sync_schedule)
 
 

--- a/tests/test_reporter_utils.py
+++ b/tests/test_reporter_utils.py
@@ -41,3 +41,5 @@ def test_reporter_sync_schedule_list():
     lis = reporter_sync_schedule
     assert len(lis) > 4
     assert "eth-usd-legacy" in lis
+    assert "morphware-v1" not in lis
+    assert "uspce-legacy" not in lis


### PR DESCRIPTION
Closes #278 
Only adds legacy and spot price queries to reporter sync schedule. Doesn't include AMPL or USPCE either.