### PR TITLE
Update DIVA Protocol response type

### DIFF
--- a/src/telliot_core/queries/diva_protocol.py
+++ b/src/telliot_core/queries/diva_protocol.py
@@ -1,19 +1,41 @@
 import logging
 from dataclasses import dataclass
 
-from telliot_core.dtypes.float_type import UnsignedFloatType
+from eth_abi import decode_single
+from eth_abi import encode_single
+
 from telliot_core.dtypes.value_type import ValueType
 from telliot_core.queries.abi_query import AbiQuery
+
 
 logger = logging.getLogger(__name__)
 
 
-# TODO
-# This is a very minimal implementation of what is needed for Diva.
-# Eventually, it'll need to fetch a viable poolId automatically and
-# it's associated response type from the DIVA contract
 @dataclass
-class divaProtocolPolygon(AbiQuery):
+class DIVAReturnType(ValueType):
+
+    abi_type: str = "(ufixed256x18,ufixed256x18)"
+
+    def encode(self, value: tuple[float]) -> bytes:
+        """An encoder for DIVA Protocol response type
+
+        Encodes a tuple of float values.
+        """
+        if len(value) != 2 or not isinstance(value[0], float) or not isinstance(value[1], float):
+            raise ValueError("Invalid response type")
+
+        return encode_single("(ufixed256x18,ufixed256x18)", tuple(int(v * 1e18) for v in value))
+
+    def decode(self, bytes_val: bytes) -> tuple[float]:
+        """A decoder for DIVA Protocol response type
+
+        Decodes a tuple of float values.
+        """
+        return tuple(float(float(v) / 1e18) for v in decode_single("(ufixed256x18,ufixed256x18)", bytes_val))
+
+
+@dataclass
+class DIVAProtocolPolygon(AbiQuery):
     """Returns the result for a given option ID (a specific prediction market) on the
     Diva Protocol on Polygon.
 
@@ -23,7 +45,7 @@ class divaProtocolPolygon(AbiQuery):
             be settled on the Diva Protocol, on the Polygon network.
 
             More about this query:
-            https://github.com/tellor-io/dataSpecs/blob/main/types/DivaProtocolPolygon.md
+            https://github.com/tellor-io/dataSpecs/blob/main/types/DIVAProtocolPolygon.md
 
             More about Diva Protocol:
             https://divaprotocol.io
@@ -35,10 +57,10 @@ class divaProtocolPolygon(AbiQuery):
     abi = [{"name": "poolId", "type": "uint256"}]
 
     @property
-    def value_type(self) -> ValueType:
-        """Data type returned for a divaProtocolPolygon query.
+    def value_type(self) -> DIVAReturnType:
+        """Data type returned for a DIVAProtocolPolygon query.
 
         - `ufixed256x18`: 256-bit unsigned integer with 18 decimals of precision
         - `packed`: false
         """
-        return UnsignedFloatType(abi_type="ufixed256x18", packed=False)
+        return DIVAReturnType(abi_type="(ufixed256x18,ufixed256x18)", packed=False)

--- a/src/telliot_core/queries/diva_protocol.py
+++ b/src/telliot_core/queries/diva_protocol.py
@@ -1,8 +1,8 @@
 import logging
 from dataclasses import dataclass
 
-from eth_abi import decode_single
-from eth_abi import encode_single
+from eth_abi import decode_abi
+from eth_abi import encode_abi
 
 from telliot_core.dtypes.value_type import ValueType
 from telliot_core.queries.abi_query import AbiQuery
@@ -16,7 +16,7 @@ class DIVAReturnType(ValueType):
 
     abi_type: str = "(ufixed256x18,ufixed256x18)"
 
-    def encode(self, value: tuple[float]) -> bytes:
+    def encode(self, value: list[float]) -> bytes:
         """An encoder for DIVA Protocol response type
 
         Encodes a tuple of float values.
@@ -24,14 +24,14 @@ class DIVAReturnType(ValueType):
         if len(value) != 2 or not isinstance(value[0], float) or not isinstance(value[1], float):
             raise ValueError("Invalid response type")
 
-        return encode_single("(ufixed256x18,ufixed256x18)", tuple(int(v * 1e18) for v in value))
+        return encode_abi(["uint256", "uint256"], [int(v * 1e18) for v in value])
 
-    def decode(self, bytes_val: bytes) -> tuple[float, ...]:
+    def decode(self, bytes_val: bytes) -> list[float]:
         """A decoder for DIVA Protocol response type
 
         Decodes a tuple of float values.
         """
-        return tuple(float(float(v) / 1e18) for v in decode_single("(ufixed256x18,ufixed256x18)", bytes_val))
+        return [float(float(v) / 1e18) for v in decode_abi(["uint256", "uint256"], bytes_val)]
 
 
 @dataclass

--- a/src/telliot_core/queries/diva_protocol.py
+++ b/src/telliot_core/queries/diva_protocol.py
@@ -26,7 +26,7 @@ class DIVAReturnType(ValueType):
 
         return encode_single("(ufixed256x18,ufixed256x18)", tuple(int(v * 1e18) for v in value))
 
-    def decode(self, bytes_val: bytes) -> tuple[float]:
+    def decode(self, bytes_val: bytes) -> tuple[float, ...]:
         """A decoder for DIVA Protocol response type
 
         Decodes a tuple of float values.

--- a/src/telliot_core/tellor/tellorflex/diva.py
+++ b/src/telliot_core/tellor/tellorflex/diva.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class PoolParameters:
-    """Source: https://github.com/tellor-io/dataSpecs/blob/main/types/DivaProtocolPolygon.md"""
+    """Source: https://github.com/tellor-io/dataSpecs/blob/main/types/DIVAProtocolPolygon.md"""
 
     reference_asset: str  # (string) Reference asset string (e.g., "BTC/USD", "ETH Gas Price (Wei)", "TVL Locked in DeFi", etc.) # noqa: E501
     expiry_time: int  # (uint256) Expiration time of the pool and as of time of final value expressed as a unix timestamp in seconds # noqa: E501
@@ -46,7 +46,11 @@ class DivaProtocolContract(Contract):
 
     def __init__(self, node: RPCEndpoint, account: Optional[ChainedAccount] = None):
         chain_id = node.chain_id
-        assert chain_id is not None and chain_id in (137, 80001, 3)  # Polygon chains & Ropsten
+        assert chain_id is not None and chain_id in (
+            137,
+            80001,
+            3,
+        )  # Polygon chains & Ropsten
 
         contract_info = contract_directory.find(chain_id=chain_id, name="diva-protocol")[0]
         if not contract_info:
@@ -85,7 +89,11 @@ class DivaOracleTellorContract(Contract):
 
     def __init__(self, node: RPCEndpoint, account: Optional[ChainedAccount] = None):
         chain_id = node.chain_id
-        assert chain_id is not None and chain_id in (137, 80001, 3)  # Polygon chains & Ropsten
+        assert chain_id is not None and chain_id in (
+            137,
+            80001,
+            3,
+        )  # Polygon chains & Ropsten
 
         contract_info = contract_directory.find(chain_id=chain_id, name="diva-oracle-tellor")[0]
         if not contract_info:

--- a/tests/test_query_diva_protocol_polygon.py
+++ b/tests/test_query_diva_protocol_polygon.py
@@ -1,29 +1,63 @@
-""" Unit tests for divaProtocolPolygon queries
+""" Unit tests for DIVAProtocolPolygon queries
 
 Copyright (c) 2021-, Tellor Development Community
 Distributed under the terms of the MIT License.
 """
 from eth_abi import decode_abi
+from eth_abi import encode_abi
+from eth_abi import encode_single
 
-from telliot_core.queries.diva_protocol import divaProtocolPolygon
+from telliot_core.queries.diva_protocol import DIVAProtocolPolygon
 
 
 def test_constructor():
     """Validate spot price query."""
-    q = divaProtocolPolygon(poolId=156)
+    q = DIVAProtocolPolygon(poolId=156)
 
     # print(q.query_id.hex())
     # print(q.query_data)
 
-    exp = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13divaProtocolPolygon\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x9c"  # noqa: E501
-
+    exp = (
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x00"
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00"
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x13DIVAProtocolPolygon"
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00"
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x9c"
+    )
     assert q.query_data == exp
 
     query_type, encoded_param_vals = decode_abi(["string", "bytes"], q.query_data)
-    assert query_type == "divaProtocolPolygon"
+    assert query_type == "DIVAProtocolPolygon"
 
     pool_id = decode_abi([q.abi[0]["type"]], encoded_param_vals)[0]
     assert pool_id == 156
 
-    exp = "96ed1e09bc6d42fa15911c36b46dd451f93ce45ecdb19fd46ecf784656a53d84"
+    exp = "551179c46e6a88b7e034b039dbe264685f1895607515ddda71daffe9e7814c20"
     assert q.query_id.hex() == exp
+
+
+def test_encode_decode_reported_val():
+    """Ensure expected encoding/decoding behavior."""
+    q = DIVAProtocolPolygon(poolId=156)
+
+    data = (1234.1234, 123.123)
+
+    data2 = tuple(int(v * 1e18) for v in data)
+    d1 = encode_abi(["ufixed256x18", "ufixed256x18"], data2)
+    d2 = encode_single("(ufixed256x18,ufixed256x18)", data2)
+    assert d1 == d2
+
+    submit_value = q.value_type.encode(data)
+    assert isinstance(submit_value, bytes)
+    assert submit_value == d1 == d2
+
+    decoded_data = q.value_type.decode(submit_value)
+    assert isinstance(decoded_data, tuple)
+    assert isinstance(decoded_data[0], float)
+    assert isinstance(decoded_data[1], float)
+    assert decoded_data == data

--- a/tests/test_query_diva_protocol_polygon.py
+++ b/tests/test_query_diva_protocol_polygon.py
@@ -45,7 +45,9 @@ def test_encode_decode_reported_val():
     """Ensure expected encoding/decoding behavior."""
     q = DIVAProtocolPolygon(poolId=156)
 
-    data = (1234.1234, 123.123)
+    # Reference asset example: ETH/USD ($2,819.35)
+    # Collateral token example: DAI/USD ($0.9996)
+    data = (2819.35, 0.9996)
 
     data2 = tuple(int(v * 1e18) for v in data)
     d1 = encode_abi(["ufixed256x18", "ufixed256x18"], data2)
@@ -55,6 +57,7 @@ def test_encode_decode_reported_val():
     submit_value = q.value_type.encode(data)
     assert isinstance(submit_value, bytes)
     assert submit_value == d1 == d2
+    print(submit_value.hex())
 
     decoded_data = q.value_type.decode(submit_value)
     assert isinstance(decoded_data, tuple)

--- a/tests/test_query_diva_protocol_polygon.py
+++ b/tests/test_query_diva_protocol_polygon.py
@@ -5,7 +5,6 @@ Distributed under the terms of the MIT License.
 """
 from eth_abi import decode_abi
 from eth_abi import encode_abi
-from eth_abi import encode_single
 
 from telliot_core.queries.diva_protocol import DIVAProtocolPolygon
 
@@ -47,20 +46,18 @@ def test_encode_decode_reported_val():
 
     # Reference asset example: ETH/USD ($2,819.35)
     # Collateral token example: DAI/USD ($0.9996)
-    data = (2819.35, 0.9996)
+    data = [2819.35, 0.9996]
 
-    data2 = tuple(int(v * 1e18) for v in data)
-    d1 = encode_abi(["ufixed256x18", "ufixed256x18"], data2)
-    d2 = encode_single("(ufixed256x18,ufixed256x18)", data2)
-    assert d1 == d2
-
+    data2 = [int(v * 1e18) for v in data]
+    d1 = encode_abi(["uint256", "uint256"], data2)
     submit_value = q.value_type.encode(data)
+
     assert isinstance(submit_value, bytes)
-    assert submit_value == d1 == d2
+    assert submit_value == d1
     print(submit_value.hex())
 
     decoded_data = q.value_type.decode(submit_value)
-    assert isinstance(decoded_data, tuple)
+    assert isinstance(decoded_data, list)
     assert isinstance(decoded_data[0], float)
     assert isinstance(decoded_data[1], float)
     assert decoded_data == data

--- a/tests/test_query_diva_protocol_polygon.py
+++ b/tests/test_query_diva_protocol_polygon.py
@@ -16,7 +16,7 @@ def test_constructor():
     # print(q.query_id.hex())
     # print(q.query_data)
 
-    exp = (
+    exp_query_data = (
         b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00@\x00"
         b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
@@ -28,7 +28,7 @@ def test_constructor():
         b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00"
         b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x9c"
     )
-    assert q.query_data == exp
+    assert q.query_data == exp_query_data
 
     query_type, encoded_param_vals = decode_abi(["string", "bytes"], q.query_data)
     assert query_type == "DIVAProtocolPolygon"
@@ -38,6 +38,11 @@ def test_constructor():
 
     exp = "551179c46e6a88b7e034b039dbe264685f1895607515ddda71daffe9e7814c20"
     assert q.query_id.hex() == exp
+
+    q = DIVAProtocolPolygon.get_query_from_data(exp_query_data)
+
+    assert isinstance(q, DIVAProtocolPolygon)
+    assert q.poolId == 156
 
 
 def test_encode_decode_reported_val():


### PR DESCRIPTION
Switching from expecting a float with 18 decimals of precision to two of the same: `(ufixed256x18,ufixed256x18)`

Closes #283 