### PR TITLE
Change cli entry point name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,4 +58,4 @@ where = src
 
 [options.entry_points]
 console_scripts =
-    telliot = telliot_core.cli.main:main
+    telliot-core = telliot_core.cli.main:main


### PR DESCRIPTION
Changes this tool's invocation name from `telliot` to `telliot-core`