### PR TITLE
Fix for Polygon Block Explorer

### DIFF
--- a/src/telliot_core/model/endpoints.py
+++ b/src/telliot_core/model/endpoints.py
@@ -113,7 +113,7 @@ default_endpoint_list = [
         provider="Matic",
         network="mainnet",
         url="https://rpc-mainnet.matic.network",
-        explorer="https://matic.network",
+        explorer="https://polygonscan.com/",
     ),
     RPCEndpoint(
         chain_id=122,


### PR DESCRIPTION
Changed from matic.network to polygonscan.
Closes issue #349 when merged. 