### PR TITLE
Fix incomplete rpc url test

### DIFF
--- a/tests/test_rpc_endpoint.py
+++ b/tests/test_rpc_endpoint.py
@@ -35,9 +35,14 @@ def test_incomplete_rpc_url():
     """an incomplete url will raise an exception in RPCEndpoint"""
     url = "https://eth-rinkeby.gateway.pokt.network/v1/lb/"
     endpt = RPCEndpoint(network=network, provider=provider, url=url)
-    # expect bad url error from requests library
-    with pytest.raises(HTTPError):
+    try:
         _ = endpt.connect()
+    except HTTPError:
+        pass  # expected
+    except ValueError as e:
+        assert "Invalid request path" in str(e)
+    else:
+        pytest.fail("Expected ValueError or HTTPError.")
 
 
 def test_endpoint_list():


### PR DESCRIPTION
- It's throwing ValueError in some cases and HTTPError in others, so I just handle both