### PR TITLE
thegraph api key

### DIFF
--- a/src/telliot_core/__init__.py
+++ b/src/telliot_core/__init__.py
@@ -1,2 +1,2 @@
 """ Telliot """
-__version__ = "0.3.6"
+__version__ = "0.3.6.dev0"

--- a/src/telliot_core/model/api_keys.py
+++ b/src/telliot_core/model/api_keys.py
@@ -38,6 +38,7 @@ default_api_keys = [
     ApiKey(name="nomics", key="", url="https://api.nomics.com/"),
     ApiKey(name="coinmarketcap", key="", url="https://pro-api.coinmarketcap.com/"),
     ApiKey(name="coingecko", key="", url="https://pro-api.coingecko.com"),
+    ApiKey(name="thegraph", key="", url="https://gateway-arbitrum.network.thegraph.com/api"),
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,35 +39,6 @@ def sepolia_cfg():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def goerli_cfg():
-    """Get goerli endpoint from config
-
-    If environment variables are defined, they will override the values in config files
-    """
-    cfg = TelliotConfig()
-
-    # Override configuration for goerli testnet
-    cfg.main.chain_id = 5
-
-    goerli_endpoint = cfg.get_endpoint()
-    # assert goerli_endpoint.network == "goerli"
-
-    if os.getenv("NODE_URL", None):
-        goerli_endpoint.url = os.environ["NODE_URL"]
-
-    goerli_accounts = find_accounts(chain_id=5)
-    if not goerli_accounts:
-        # Create a test account using PRIVATE_KEY defined on github.
-        key = os.getenv("PRIVATE_KEY", None)
-        if key:
-            ChainedAccount.add("git-goerli-key", chains=5, key=os.environ["PRIVATE_KEY"], password="")
-        else:
-            raise Exception("Need a goerli account")
-
-    return cfg
-
-
-@pytest.fixture(scope="session", autouse=True)
 def mumbai_cfg():
     """Return a test telliot configuration for use on polygon-mumbai
 

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -15,3 +15,9 @@ def test_api_key_list():
 
     res = lis.find(name="coinmarketcap")[0]
     assert res.url == "https://pro-api.coinmarketcap.com/"
+
+    res = lis.find(name="coingecko")[0]
+    assert res.url == "https://pro-api.coingecko.com"
+
+    res = lis.find(name="thegraph")[0]
+    assert res.url == "https://gateway-arbitrum.network.thegraph.com/api"


### PR DESCRIPTION
This PR goes with telliot-feeds PR #790 to fix the uniswap subgraph sources. Telliot users will need to set up payments to the graph for their decentralized services.

Prints the basic config to `api_keys.yaml` when the user does `telliot config init`.