### PR TITLE
Add Layer Networks and Fix Tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     click
     PyYAML >= 6.0
     requests
-    web3 >= 6, < 7
+    web3 >= 7
     clamfig == 0.1.3
     chained-accounts == 0.0.1
 

--- a/src/telliot_core/apps/core.py
+++ b/src/telliot_core/apps/core.py
@@ -84,6 +84,8 @@ NETWORKS = {
     534352: "scroll",
     8453: "base",
     1135: "lisk",
+    5293783784: "layertest-4",
+    8355671: "tellor",
 }
 
 LOGLEVEL_MAP = {

--- a/src/telliot_core/contract/listener.py
+++ b/src/telliot_core/contract/listener.py
@@ -19,13 +19,45 @@ from typing import Literal
 import aiohttp
 from aiohttp.client import _WSRequestContextManager
 from hexbytes import HexBytes
-from web3._utils.method_formatters import block_formatter
-from web3._utils.method_formatters import log_entry_formatter
-from web3._utils.method_formatters import syncing_formatter
+from web3.datastructures import AttributeDict
 
 logger = logging.getLogger(__name__)
 
 AsyncCallable = Callable[[Any], Awaitable[Any]]
+
+
+def _hex_to_int(value: Any) -> Any:
+    """Convert hex strings to integers recursively in data structures."""
+    if isinstance(value, str) and value.startswith('0x'):
+        try:
+            return int(value, 16)
+        except ValueError:
+            return value
+    elif isinstance(value, dict):
+        return {k: _hex_to_int(v) for k, v in value.items()}
+    elif isinstance(value, list):
+        return [_hex_to_int(item) for item in value]
+    return value
+
+
+def block_formatter(block_data: dict) -> AttributeDict:
+    """Format block data similar to web3 v6 block_formatter."""
+    formatted = _hex_to_int(block_data)
+    return AttributeDict(formatted)
+
+
+def log_entry_formatter(log_data: dict) -> AttributeDict:
+    """Format log entry data similar to web3 v6 log_entry_formatter."""
+    formatted = _hex_to_int(log_data)
+    return AttributeDict(formatted)
+
+
+def syncing_formatter(sync_data: Any) -> Any:
+    """Format syncing data similar to web3 v6 syncing_formatter."""
+    if isinstance(sync_data, dict):
+        formatted = _hex_to_int(sync_data)
+        return AttributeDict(formatted)
+    return sync_data
 
 SubscriptionType = Literal["newHeads", "logs", "newPendingTransactions", "syncing"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     pytest-asyncio
     eth-ape
 commands =
-    ape plugins install .
+    ape plugins install . --upgrade --yes
     ape compile
     pytest --cov --cov-report xml
 


### PR DESCRIPTION
Checking if this PR passes github action tests for now.

This PR adds `layertest-4` and `tellor-1` to the list of supported chains, and attempts to fix the github action test setup. The solution seems to be updating to web3 version 7+ and changing the ape plugins install command to use `--upgrade --yes`flags. We shouldn't merge this until we see how it works when installed alongside telliot-feeds.